### PR TITLE
Build nits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,9 @@
+# Running 'make' will just verify
+default: verify
+
+# 'make all' will extract and build
 all: world
-world: verify
+world: verify extract lib
 
 # Many thanks to Jonathan Protzenko for its Low* tutorial
 

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,9 @@ world: verify extract lib
 
 # Many thanks to Jonathan Protzenko for its Low* tutorial
 
-FSTAR_HOME ?= $(realpath $(dir $(shell which fstar.exe))/..)
-
 include Makefile.include
 
-FSTAR_EXE = $(FSTAR_HOME)/bin/fstar.exe
+FSTAR_EXE ?= fstar.exe
 KRML_EXE = $(KRML_HOME)/krml
 
 FSTAR_OPTIONS = $(SIL) --cache_checked_modules $(FSTAR_EMACS_PARAMS) \

--- a/Makefile.include
+++ b/Makefile.include
@@ -1,7 +1,3 @@
-ifeq (,$(FSTAR_HOME))
-  $(error FSTAR_HOME is not defined)
-endif
-
 ifeq (,$(STEEL_HOME))
   $(error STEEL_HOME is not defined)
 endif
@@ -10,12 +6,8 @@ ifeq (,$(KRML_HOME))
   $(error KRML_HOME is not defined)
 endif
 
-ifndef FSTAR_ULIB
-  FSTAR_ULIB := $(shell if test -d "$(FSTAR_HOME)/ulib" ; then echo "$(FSTAR_HOME)/ulib" ; else echo "$(FSTAR_HOME)/lib/fstar" ; fi)
-endif
-
 ifndef STEEL_LIB
-  STEEL_LIB := $(shell if test -f "$(FSTAR_HOME)/ulib/experimental/Steel.Effect.fsti" ; then echo "$(FSTAR_HOME)/ulib/experimental" ; else echo "$(STEEL_HOME)/lib/steel" ; fi)
+  STEEL_LIB := $(STEEL_HOME)/lib/steel
 endif
 
 ifndef KRML_LIB
@@ -44,7 +36,6 @@ SOURCE_DIRS = \
 
 INCLUDE_DIRS = \
   $(SOURCE_DIRS) \
-  $(FSTAR_ULIB)/.cache \
   $(STEEL_LIB)
 
 FSTAR_EMACS_PARAMS = $(addprefix --include ,$(INCLUDE_DIRS)) \

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ See `BUILD.md` to reverify and extract StarMalloc from scratch using F\*, Steel 
 ### Light build
 
 With only a C compiler as dependency, the following command will produce `out/starmalloc.so` out of pre-extracted C files (`dist/` directory) and vendored C files (`vendor/` directory):
-`FSTAR_HOME=1 STEEL_HOME=1 KRML_HOME=1 NODEPEND=1 VENDOR=1 make light`.
+`STEEL_HOME=1 KRML_HOME=1 NODEPEND=1 VENDOR=1 make light`.
 (TODO: this command should be easier)
 
 - `{FSTAR,STEEl,KRML}_HOME=1` : so that checks in `Makefile.include` will not fail

--- a/flake.nix
+++ b/flake.nix
@@ -44,7 +44,6 @@
         enableParallelBuilding = true;
         buildInputs = [ ];
         # TODO: unaesthetic workaround, could this be improved?
-        FSTAR_HOME = 1;
         STEEL_HOME = 1;
         KRML_HOME = 1;
         # use vendored files, as this would require Steel and KaRaMeL
@@ -73,7 +72,6 @@
         ];
         enableParallelBuilding = true;
         buildInputs = [ fstar steel karamel ];
-        FSTAR_HOME = fstar;
         STEEL_HOME = steel;
         KRML_HOME = karamel;
         installPhase = "mkdir $out && cp -r dist out/*.so $out";

--- a/setup-all.sh
+++ b/setup-all.sh
@@ -7,6 +7,7 @@ readonly PROGNAME=$(basename $0)
 
 OTHERFLAGS=${OTHERFLAGS:=""}
 CORES=${CORES:=$(nproc)}
+FSTAR_EXE=${FSTAR_EXE:=fstar.exe}
 
 setup() {
   echo "0. Setup"
@@ -16,8 +17,8 @@ setup() {
   	exit 1
   fi
 
-  if [[ -z "${FSTAR_HOME}" ]]; then
-  	echo "FSTAR_HOME env var is not set, exiting"
+  if [[ -z "$(which ${FSTAR_EXE} 2>/dev/null)" ]]; then
+	echo "FSTAR_EXE (=${FSTAR_EXE}) not found, exiting"
   	exit 1
   fi
 


### PR DESCRIPTION
Removing the need for FSTAR_HOME, and changing `make all` to actually build everything. I think the Nix build still works but please check.

(I don't feel strongly about this, feel free to drop. --- Edit: actually the FSTAR_HOME removal is needed so I can add this to check-world in F*.)